### PR TITLE
Fix #17 - Update dependencies / add 16 KB page sizes support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "org.chickenhook.restrictionbypass.app"
-    compileSdk 34
+    compileSdk 35
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -13,8 +13,8 @@ android {
     }
     defaultConfig {
         applicationId "org.chickenhook.restrictionbypass.app"
-        minSdk 19
-        targetSdk 33
+        minSdk 21
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 
@@ -32,11 +32,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation project(':restrictionbypass')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,24 +3,22 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
+        classpath 'com.android.tools.build:gradle:8.8.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10"
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
-
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/restrictionbypass/build.gradle
+++ b/restrictionbypass/build.gradle
@@ -4,14 +4,15 @@ apply plugin: 'maven-publish'
 group = 'com.github.ChickenHook'
 android {
     namespace "org.chickenhook.restrictionbypass"
-    compileSdk 34
+    compileSdk 35
+    ndkVersion "28.0.13004108"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
-        minSdk 19
-        targetSdk 33
+        minSdk 21
+        targetSdk 35
         versionCode 2
         versionName "2.4"
 
@@ -63,8 +64,8 @@ publishing {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }


### PR DESCRIPTION
I had to bump `minSdk` to `21`.
If you would like to keep support for sdk 19 and 20, you can revert to `minSdk 19` and add `android.ndk.suppressMinSdkVersionError=21` to `gradle.properties` (but it’s no longer officially supported by the NDK).

Fix #17 - Add support for devices with 16 KB page sizes (you can try it in an emulator, and you will see it no longer crashes)